### PR TITLE
Separate arcMap generation from writing to file

### DIFF
--- a/ContourTree/ContourTree.cpp
+++ b/ContourTree/ContourTree.cpp
@@ -145,6 +145,7 @@ ContourTree::computeArcMap() {
 
     return {arcNo, nodeids, nodefns, nodeTypes, arcs};
 }
+}
 void ContourTree::output(std::string fileName) {
     std::cout << "removing deg-2 nodes and computing segmentation" << std::endl;
 

--- a/ContourTree/ContourTree.cpp
+++ b/ContourTree/ContourTree.cpp
@@ -99,15 +99,11 @@ void ContourTree::computeCT() {
     }
 }
 
-void ContourTree::output(std::string fileName) {
-    std::cout << "removing deg-2 nodes and computing segmentation" << std::endl;
+std::tuple<uint32_t, std::vector<int64_t>, std::vector<scalar_t>, std::vector<char>,
+           std::vector<int64_t>>
+ContourTree::computeArcMap() {
 
-    // saving some memory
-    nodesJoin.clear();
-    nodesJoin.shrink_to_fit();
-    nodesSplit.clear();
-    nodesSplit.shrink_to_fit();
-
+    uint32_t arcNo = 0;
     std::vector<int64_t> nodeids;
     std::vector<scalar_t> nodefns;
     std::vector<char> nodeTypes;
@@ -115,7 +111,7 @@ void ContourTree::output(std::string fileName) {
 
     arcMap.resize(nv, -1);
 
-    uint32_t arcNo = 0;
+    for (int64_t i = 0; i < nv; i++) {
     for(int64_t i = 0;i < nv;i ++) {
         // go in sorted order
         int64_t v = tree->sv[i];
@@ -146,6 +142,19 @@ void ContourTree::output(std::string fileName) {
             arcNo ++;
         }
     }
+
+    return {arcNo, nodeids, nodefns, nodeTypes, arcs};
+}
+void ContourTree::output(std::string fileName) {
+    std::cout << "removing deg-2 nodes and computing segmentation" << std::endl;
+
+    // saving some memory
+    nodesJoin.clear();
+    nodesJoin.shrink_to_fit();
+    nodesSplit.clear();
+    nodesSplit.shrink_to_fit();
+
+    auto [arcNo, nodeids, nodefns, nodeTypes, arcs] = computeArcMap();
 
     // write meta data
     std::cout << "Writing meta data" << std::endl;

--- a/ContourTree/ContourTree.hpp
+++ b/ContourTree/ContourTree.hpp
@@ -4,6 +4,7 @@
 #include <string>
 #include <vector>
 
+#include "constants.h"
 namespace contourtree {
 
 class MergeTree;
@@ -22,6 +23,9 @@ public:
 
     void setup(const MergeTree * tree);
     void computeCT();
+    std::tuple<uint32_t, std::vector<int64_t>, std::vector<scalar_t>, std::vector<char>,
+               std::vector<int64_t>>
+    computeArcMap();
     void output(std::string fileName);
 
 private:

--- a/ContourTree/MergeTree.hpp
+++ b/ContourTree/MergeTree.hpp
@@ -29,7 +29,8 @@ public:
     void computeTree(ScalarFunction* data, TreeType type);
     void computeJoinTree();
     void computeSplitTree();
-    void computeArcMap();
+    std::tuple<uint32_t, uint32_t, std::vector<int64_t>, std::vector<scalar_t>, std::vector<char>,
+        std::vector<int64_t>> computeArcMap(TreeType tree);
     const std::vector<uint32_t>& getArcMap(TreeType type) const;
     void output(std::string fileName, TreeType tree);
 

--- a/ContourTree/MergeTree.hpp
+++ b/ContourTree/MergeTree.hpp
@@ -29,6 +29,8 @@ public:
     void computeTree(ScalarFunction* data, TreeType type);
     void computeJoinTree();
     void computeSplitTree();
+    void computeArcMap();
+    const std::vector<uint32_t>& getArcMap(TreeType type) const;
     void output(std::string fileName, TreeType tree);
 
 protected:
@@ -53,6 +55,7 @@ public:
 
     std::set<int64_t> set;
     ContourTree ctree;
+    std::vector<uint32_t> arcMap;
 
 private:
     std::vector<int64_t> star;


### PR DESCRIPTION
I separated the generation of the arcMap from writing it to file since writing to file might not be needed. One could instead directly work with the arcMap.