### PR TITLE
Python Wheel Building

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 *.pro.user
 *.o
 build-*
+
+# built wheel directories
+dist/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,7 @@ set(MAIN_SOURCE_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp-example/main.cpp
 )
 
+option(BUILD_PYCT "Build the Python module" OFF)
 
 # Create library
 add_library(ContourTree STATIC ${SOURCE_FILES} ${HEADER_FILES})
@@ -51,35 +52,37 @@ target_link_libraries(TestContourTree ContourTree)
 target_include_directories(ContourTree PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/ContourTree)
 target_include_directories(TestContourTree PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/ContourTree)
 
-# Python bindings (pybind11) - Dynamically Fetched
-include(FetchContent)
+if (BUILD_PYCT)
+    # Python bindings (pybind11) - Dynamically Fetched
+    include(FetchContent)
 
-FetchContent_Declare(
-    pybind11
-    GIT_REPOSITORY https://github.com/pybind/pybind11.git
-    GIT_TAG        v2.13.0
-)
-# Make sure the pybind11 content is available
-FetchContent_MakeAvailable(pybind11)
+    FetchContent_Declare(
+        pybind11
+        GIT_REPOSITORY https://github.com/pybind/pybind11.git
+        GIT_TAG        v2.13.0
+    )
+    # Make sure the pybind11 content is available
+    FetchContent_MakeAvailable(pybind11)
 
-find_package(Python3 COMPONENTS Interpreter Development NumPy REQUIRED)
+    find_package(Python3 COMPONENTS Interpreter Development NumPy REQUIRED)
 
-add_library(pyct MODULE
-    python/PyBindings.cpp
-)
-target_link_libraries(pyct PRIVATE pybind11::module ContourTree Python3::Python Python3::NumPy)
-target_include_directories(pyct PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/ContourTree)
-set_target_properties(pyct PROPERTIES
-    PREFIX ""
-    OUTPUT_NAME "pyct"
-    SUFFIX ".pyd"
-)
+    add_library(pyct MODULE
+        python/PyBindings.cpp
+    )
+    target_link_libraries(pyct PRIVATE pybind11::module ContourTree Python3::Python Python3::NumPy)
+    target_include_directories(pyct PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/ContourTree)
+    set_target_properties(pyct PROPERTIES
+        PREFIX ""
+        OUTPUT_NAME "pyct"
+        SUFFIX ".pyd"
+    )
 
-# Install the library and the python module into the wheel
-install(TARGETS pyct 
-        DESTINATION pyct 
-        COMPONENT python)
+    # Install the library and the python module into the wheel
+    install(TARGETS pyct 
+            DESTINATION pyct 
+            COMPONENT python)
 
-install(FILES __init__.py 
-        DESTINATION pyct 
-        COMPONENT python)
+    install(FILES __init__.py 
+            DESTINATION pyct 
+            COMPONENT python)
+endif ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.11)
 
 project(ContourTree)
 
@@ -51,8 +51,17 @@ target_link_libraries(TestContourTree ContourTree)
 target_include_directories(ContourTree PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/ContourTree)
 target_include_directories(TestContourTree PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/ContourTree)
 
-# Python bindings (pybind11)
-find_package(pybind11 REQUIRED)
+# Python bindings (pybind11) - Dynamically Fetched
+include(FetchContent)
+
+FetchContent_Declare(
+    pybind11
+    GIT_REPOSITORY https://github.com/pybind/pybind11.git
+    GIT_TAG        v2.13.0
+)
+# Make sure the pybind11 content is available
+FetchContent_MakeAvailable(pybind11)
+
 find_package(Python3 COMPONENTS Interpreter Development NumPy REQUIRED)
 
 add_library(pyct MODULE
@@ -65,3 +74,12 @@ set_target_properties(pyct PROPERTIES
     OUTPUT_NAME "pyct"
     SUFFIX ".pyd"
 )
+
+# Install the library and the python module into the wheel
+install(TARGETS pyct 
+        DESTINATION pyct 
+        COMPONENT python)
+
+install(FILES __init__.py 
+        DESTINATION pyct 
+        COMPONENT python)

--- a/README.md
+++ b/README.md
@@ -17,17 +17,32 @@ to compute the contour tree of an input scalar function.
 hyper volume as the importance measure, and obtain a mapping between the input data and the simplified features. 
 This is typically used when analyzing the data (like it was used in TopoAngler)
 
-It currently uses qmake to build. An example of using the code on a structured 3D grid is provided in main.cpp. 
+An example of using the code on a structured 3D grid is provided in main.cpp. 
 A 2D grid input can be used by setting the value of *dimz* = 1. The *TriMesh* class can instead be used for a triangle mesh input.
 Note that, support for other input types can be added by implementing a subclass of the *ScalarFunction* interface.
 
 I would appreciate it if you can let me know (http://www.harishd.com/home/contact/) if you use this code, 
 and optionally, how you are using it (this is purely to keep approximate count of the users of this code).
 
-### Building Wheels
+### 🛠️ Building the C Library
+
+The C library can be built using CMake. Run the following commands:
+
+1. `$ mkdir build-main`
+1. `$ cd build-main`
+1. `$ cmake ..` OR `cmake -DBUILD_PYCT=ON ..` if you'd like to build the python module as well.
+1. `$ cmake --build . --config Release` OR `cmake --build . --config Debug`
+
+The library (and any other built components) should now be available in `build-main/Release` or `build-main/Debug`.
+
+### 🎲 Installing via Pip
+
+1. Create a virtual env (or conda env) with python 3.7 or later
+1. Activate the virtual environment and run `pip install .`
+
+### 🐍 Building Python Wheels
 To build an installable python wheel, follow these steps:
 
 1. Create a virtual env (or conda env) with python 3.7 or later
 1. Activate the virtual environment and run `pip install numpy build`
 1. Run `python -m build .`
-1. The built wheel should now be in the `dist/` directory, and can be installed by running `pip install dist/pyct-1.0.0-cp3xx-cp3xx-os_arch.whl`

--- a/README.md
+++ b/README.md
@@ -24,3 +24,10 @@ Note that, support for other input types can be added by implementing a subclass
 I would appreciate it if you can let me know (http://www.harishd.com/home/contact/) if you use this code, 
 and optionally, how you are using it (this is purely to keep approximate count of the users of this code).
 
+### Building Wheels
+To build an installable python wheel, follow these steps:
+
+1. Create a virtual env (or conda env) with python 3.7 or later
+1. Activate the virtual environment and run `pip install numpy build`
+1. Run `python -m build .`
+1. The built wheel should now be in the `dist/` directory, and can be installed by running `pip install dist/pyct-1.0.0-cp3xx-cp3xx-os_arch.whl`

--- a/__init__.py
+++ b/__init__.py
@@ -1,0 +1,1 @@
+from .pyct import *

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,40 @@
+[build-system]
+requires = [
+  "scikit-build-core[pyproject]",
+  "pybind11",
+  "cibuildwheel",
+  "numpy",
+]
+build-backend = "scikit_build_core.build"
+
+[project]
+name = "pyct"
+version = "1.0.0"
+description = "Python bindings for the ContourTree C++ library"
+authors = [
+  { name = "Harish Doraiswamy" },
+]
+license = { text = "BSD-3-Clause" }
+dependencies = [
+  "numpy",
+]
+
+# ──────────────────────────────────────────────────────────
+[tool.scikit-build]
+# Where the cmake builds files go during the building process
+build-dir = "build-pyct/"
+
+# Which Python packages go into your wheel
+
+wheel.packages = ["pyct"]
+install.strip = false
+install.components = ["python"]
+
+# ──────────────────────────────────────────────────────────
+[tool.scikit-build.cmake]
+
+# build-type = "Debug"
+source-dir = "."
+
+# After building, invoke `install`
+targets = ["install"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,9 @@ install.components = ["python"]
 
 # build-type = "Debug"
 source-dir = "."
+args = [
+  "-DBUILD_PYCT"
+]
 
 # After building, invoke `install`
 targets = ["install"]


### PR DESCRIPTION
Added a barebones pyproject.toml file to allow for easily building installable python wheels using scikit-build. Added instructions for the same in the README.

Also, added logic to dynamically fetch pybind11, removing the need to install it manually before building.

