### PR TITLE
Use shared_ptr holders for pybind

### DIFF
--- a/ContourTree/MergeTree.cpp
+++ b/ContourTree/MergeTree.cpp
@@ -14,7 +14,7 @@ namespace contourtree {
 
 MergeTree::MergeTree() { newRoot = 0; }
 
-void MergeTree::computeTree(ScalarFunction* data, TreeType type) {
+void MergeTree::computeTree(std::shared_ptr<ScalarFunction> data, TreeType type) {
     this->data = data;
     std::chrono::time_point<std::chrono::system_clock> ct, en;
     ct = std::chrono::system_clock::now();

--- a/ContourTree/MergeTree.hpp
+++ b/ContourTree/MergeTree.hpp
@@ -8,22 +8,23 @@
 #include "ContourTree.hpp"
 #include <set>
 #include <string>
+#include <memory>
 
 namespace contourtree {
 
 class MergeTree {
 public:
     struct Compare {
-        Compare(ScalarFunction* data) : data(data) {}
+        Compare(std::shared_ptr<ScalarFunction> data): data(data) {}
         bool operator()(int64_t v1, int64_t v2) { return data->lessThan(v1, v2); }
 
-        ScalarFunction* data;
+        std::shared_ptr<ScalarFunction> data;
     };
 
 public:
     MergeTree();
 
-    void computeTree(ScalarFunction* data, TreeType type);
+    void computeTree(std::shared_ptr<ScalarFunction> data, TreeType type);
     void computeJoinTree();
     void computeSplitTree();
     void output(std::string fileName, TreeType tree);
@@ -35,7 +36,7 @@ protected:
     void processVertexSplit(int64_t v);
 
 public:
-    ScalarFunction* data;
+    std::shared_ptr<ScalarFunction> data;
     std::vector<int64_t> cpMap;
     DisjointSets<int64_t> nodes;
 

--- a/python/PyBindings.cpp
+++ b/python/PyBindings.cpp
@@ -2,6 +2,7 @@
 #include <pybind11/stl.h>
 #include <pybind11/numpy.h>
 #include <vector>
+#include <memory>
 #include "GraphScalarFunction.hpp"
 #include "constants.h"
 #include "TriMesh.hpp"
@@ -33,7 +34,7 @@ PYBIND11_MODULE(pyct, m) {
         .value("TypeContourTree", contourtree::TypeContourTree);
     
     // Expose ScalarFunction base class
-    py::class_<contourtree::ScalarFunction>(m, "ScalarFunction")
+    py::class_<contourtree::ScalarFunction, std::shared_ptr<contourtree::ScalarFunction>>(m, "ScalarFunction")
         .def("getMaxDegree", &contourtree::ScalarFunction::getMaxDegree)
         .def("getVertexCount", &contourtree::ScalarFunction::getVertexCount)
         .def("getStar", [](contourtree::ScalarFunction& self, int64_t v) {
@@ -46,7 +47,7 @@ PYBIND11_MODULE(pyct, m) {
         .def("getFunctionValue", &contourtree::ScalarFunction::getFunctionValue);
     
     // Expose GraphScalarFunction class
-    py::class_<contourtree::GraphScalarFunction, contourtree::ScalarFunction>(m, "GraphScalarFunction")
+    py::class_<contourtree::GraphScalarFunction, std::shared_ptr<contourtree::GraphScalarFunction>, contourtree::ScalarFunction>(m, "GraphScalarFunction")
         .def(py::init<>())
         .def("getVertexCount", &contourtree::GraphScalarFunction::getVertexCount)
         .def("initialize", &contourtree::GraphScalarFunction::initialize,
@@ -57,7 +58,7 @@ PYBIND11_MODULE(pyct, m) {
              "Update function values");
 
     // Expose TriMesh class
-    py::class_<contourtree::TriMesh, contourtree::ScalarFunction>(m, "TriMesh")
+    py::class_<contourtree::TriMesh, std::shared_ptr<contourtree::TriMesh>, contourtree::ScalarFunction>(m, "TriMesh")
         .def(py::init<>())
         .def("getVertexCount", &contourtree::TriMesh::getVertexCount)
         .def("getFunctionValue", &contourtree::TriMesh::getFunctionValue)
@@ -65,7 +66,7 @@ PYBIND11_MODULE(pyct, m) {
 
     // Grid3D (template) bindings: instantiate for float and double
     using Grid3DUint8 = contourtree::Grid3D<uint8_t>;
-    py::class_<Grid3DUint8, contourtree::ScalarFunction>(m, "Grid3DUint8")
+    py::class_<Grid3DUint8, std::shared_ptr<Grid3DUint8>, contourtree::ScalarFunction>(m, "Grid3DUint8")
         .def(py::init<int,int,int>(), py::arg("resx"), py::arg("resy"), py::arg("resz"))
         .def("getVertexCount", &Grid3DUint8::getVertexCount)
         .def("getFunctionValue", &Grid3DUint8::getFunctionValue)
@@ -75,7 +76,7 @@ PYBIND11_MODULE(pyct, m) {
         .def_readonly("dimz", &Grid3DUint8::dimz);
 
     using Grid3DFloat = contourtree::Grid3D<float>;
-    py::class_<Grid3DFloat, contourtree::ScalarFunction>(m, "Grid3DFloat")
+    py::class_<Grid3DFloat, std::shared_ptr<Grid3DFloat>, contourtree::ScalarFunction>(m, "Grid3DFloat")
         .def(py::init<int,int,int>(), py::arg("resx"), py::arg("resy"), py::arg("resz"))
         .def("getVertexCount", &Grid3DFloat::getVertexCount)
         .def("getFunctionValue", &Grid3DFloat::getFunctionValue)
@@ -85,7 +86,7 @@ PYBIND11_MODULE(pyct, m) {
         .def_readonly("dimz", &Grid3DFloat::dimz);
 
     using Grid3DDouble = contourtree::Grid3D<double>;
-    py::class_<Grid3DDouble, contourtree::ScalarFunction>(m, "Grid3DDouble")
+    py::class_<Grid3DDouble, std::shared_ptr<Grid3DDouble>, contourtree::ScalarFunction>(m, "Grid3DDouble")
         .def(py::init<int,int,int>(), py::arg("resx"), py::arg("resy"), py::arg("resz"))
         .def("getVertexCount", &Grid3DDouble::getVertexCount)
         .def("getFunctionValue", &Grid3DDouble::getFunctionValue)
@@ -95,7 +96,7 @@ PYBIND11_MODULE(pyct, m) {
         .def_readonly("dimz", &Grid3DDouble::dimz);
 
     // Expose MergeTree class
-    py::class_<contourtree::MergeTree>(m, "MergeTree")
+    py::class_<contourtree::MergeTree, std::shared_ptr<contourtree::MergeTree>>(m, "MergeTree")
         .def(py::init<>())
         .def("computeTree", &contourtree::MergeTree::computeTree,
                 py::arg("data"), py::arg("treeType"),
@@ -105,23 +106,23 @@ PYBIND11_MODULE(pyct, m) {
                 "Write tree data to files with the given base name");
 
     // Expose ContourTreeData class (minimal)
-    py::class_<contourtree::ContourTreeData>(m, "ContourTreeData")
+    py::class_<contourtree::ContourTreeData, std::shared_ptr<contourtree::ContourTreeData>>(m, "ContourTreeData")
         .def(py::init<>())
         .def("loadBinFile", &contourtree::ContourTreeData::loadBinFile, py::arg("filename"), "Load data from a binary file");
 
     // Base class for similarity functions (no Python overrides needed right now)
-    py::class_<contourtree::SimFunction>(m, "SimFunction");
+    py::class_<contourtree::SimFunction, std::shared_ptr<contourtree::SimFunction>>(m, "SimFunction");
 
     // Persistence and HyperVolume constructors
-    py::class_<contourtree::Persistence, contourtree::SimFunction>(m, "Persistence")
+    py::class_<contourtree::Persistence, std::shared_ptr<contourtree::Persistence>, contourtree::SimFunction>(m, "Persistence")
         .def(py::init<const contourtree::ContourTreeData&>(), py::arg("ctData"));
 
-    py::class_<contourtree::HyperVolume, contourtree::SimFunction>(m, "HyperVolume")
+    py::class_<contourtree::HyperVolume, std::shared_ptr<contourtree::HyperVolume>, contourtree::SimFunction>(m, "HyperVolume")
         .def(py::init<const contourtree::ContourTreeData&, std::string>(),
              py::arg("ctData"), py::arg("partFile"));
 
     // Expose SimplifyCT class
-    py::class_<contourtree::SimplifyCT>(m, "SimplifyCT")
+    py::class_<contourtree::SimplifyCT, std::shared_ptr<contourtree::SimplifyCT>>(m, "SimplifyCT")
         .def(py::init<>())
         .def("setInput", &contourtree::SimplifyCT::setInput, py::arg("data"))
         .def(
@@ -132,14 +133,14 @@ PYBIND11_MODULE(pyct, m) {
         .def("outputOrder", &contourtree::SimplifyCT::outputOrder, py::arg("fileName"), py::arg("normalize"), "Write the branch removal order to disk");
 
     // Expose TopologicalFeatures::Feature class
-    py::class_<contourtree::Feature>(m, "Feature")
+    py::class_<contourtree::Feature, std::shared_ptr<contourtree::Feature>>(m, "Feature")
         .def(py::init<>())
         .def_readwrite("arcs", &contourtree::Feature::arcs)
         .def_readwrite("frm", &contourtree::Feature::from)
         .def_readwrite("to", &contourtree::Feature::to);
 
     // Expose TopologicalFeatures class
-    py::class_<contourtree::TopologicalFeatures>(m, "TopologicalFeatures")
+    py::class_<contourtree::TopologicalFeatures, std::shared_ptr<contourtree::TopologicalFeatures>>(m, "TopologicalFeatures")
         .def(py::init<>())
         .def("loadData", &contourtree::TopologicalFeatures::loadData, py::arg("filename"))
         .def("getArcFeatures", [](contourtree::TopologicalFeatures& self, int topk, float th) {
@@ -154,14 +155,14 @@ PYBIND11_MODULE(pyct, m) {
         }, py::arg("topk"), py::arg("th") = 0.0f, "Returns tuple of (features, updated_topk)");
 
     // Expose Point struct
-    py::class_<contourtree::Point>(m, "Point")
+    py::class_<contourtree::Point, std::shared_ptr<contourtree::Point>>(m, "Point")
         .def(py::init<>())
         .def_readwrite("x", &contourtree::Point::x)
         .def_readwrite("y", &contourtree::Point::y)
         .def_readwrite("z", &contourtree::Point::z);
 
     // Expose LayoutCT class
-    py::class_<contourtree::LayoutCT>(m, "LayoutCT")
+    py::class_<contourtree::LayoutCT, std::shared_ptr<contourtree::LayoutCT>>(m, "LayoutCT")
         .def(py::init<contourtree::TopologicalFeatures*>(), py::arg("tf"))
         .def("layoutTree", &contourtree::LayoutCT::layoutTree, py::arg("simplifiedCount"))
         .def("getNodeLocations", &contourtree::LayoutCT::getNodeLocations);


### PR DESCRIPTION
Prevents pre-emptive garbage collection of objects, leading to invalid states.